### PR TITLE
Add window function data and loading it in to SysSim; not yet using it.

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -32,13 +32,40 @@ Q: What is the difference between q1_q16_koi_cand.csv and q1_q16_koi.csv?
 A: Danley Hsu generated q1_q16_koi_cand.csv based on q1_q16_koi.csv as well as previous KOI catalogs.  The primary difference is that he has used disposition information from previous KOI catalogs that was not reflected in the raw Q16 KOI catalog to select all KOIs with the "candidate" disposition.
 
 
-KeplerMAST_TargetProperties.csv contains a summary of key properties for Kepler Targets that are not included in the other catalogs. 
-This information was gathered from the Kepler portion of the Mikulski Archive for Space Telescopes (MAST) at archive.stsci.edu/kepler using a CasJobs query. 
-The large database of all Kepler MAST data was ingested and resummarized into several columns. A focus was on identifying whether the lightcurve of a 
-particular target ("kepid") during a particular month/quarter was obtained as part of the Exoplanet search (e.g., under the "Investigation ID" of "EX") or not. 
-We also gathered information on the availability of Short Cadence data. Thus the "LCEXst_quarters" is the "quarter string" for Quarters 1-17 with a 1 if
-this target was observed (with LC) under the EX Investigation ID and 0 if not. (Quarter 0 is not included in the quarter strings, following the stellar catalog
-convention.) "LCst_quarters" reports observations of any kind and should be identical to the quarter string from the stellar catalog. Short Cadence quarter
-strings are also provided, but here the digit 0, 1, 2, or 3 represents whether 0, 1, 2, or 3 months were obtained with Short Cadence data (both under the "EX"
-program and overall). We also summarize these quarter strings with single numbers indicating the number of quarters obtained under "EX" / overall in LC / SC 
-mode. (Note that numSCEXqtrs and numSCqtrs are floats since fractional quarters are possible.) We also elected to store the skygroup ID for each target. 
+KeplerMAST_TargetProperties.csv 
+KeplerMAST_TargetProperties.csv contains a summary of key properties for Kepler Targets that are not included 
+in the other catalogs. This information was gathered from the Kepler portion of the Mikulski Archive for Space 
+Telescopes (MAST) at archive.stsci.edu/kepler using a CasJobs query. The large database of all Kepler MAST 
+data was ingested and resummarized into several columns. A focus was on identifying whether the lightcurve of 
+a particular target ("kepid") during a particular month/quarter was obtained as part of the Exoplanet search 
+(e.g., under the "Investigation ID" of "EX") or not. We also gathered information on the availability of Short 
+Cadence data. Thus the "LCEXst_quarters" is the "quarter string" for Quarters 1-17 with a 1 if this target was 
+observed (with LC) under the EX Investigation ID and 0 if not. (Quarter 0 is not included in the quarter 
+strings, following the stellar catalog convention.) "LCst_quarters" reports observations of any kind and 
+should be identical to the quarter string from the stellar catalog. Short Cadence quarter strings are also 
+provided, but here the digit 0, 1, 2, or 3 represents whether 0, 1, 2, or 3 months were obtained with Short 
+Cadence data (both under the "EX" program and overall). We also summarize these quarter strings with single 
+numbers indicating the number of quarters obtained under "EX" / overall in LC / SC mode. (Note that 
+numSCEXqtrs and numSCqtrs are floats since fractional quarters are possible.) We also elected to store the 
+skygroup ID for each target for future reference. Contact Darin Ragozzine for more questions. 
+
+DR25topwinfuncs.jld 
+
+DR25topwinfuncs.jld is a file that contains a summary of window function data taken from the DR25 Completeness 
+Products (https://exoplanetarchive.ipac.caltech.edu/docs/KSCI-19101-002.pdf). window_func_array contains an 
+array of window function data linearly interpolated to a uniform period grid and available for each duration, 
+where 1 means that this target at this period/duration was observed enough so that 100% of phases would have 
+led to the detection of 3 transits (actually, 3 TPS-weighted transits). Most Kepler targets have window 
+functions between 0 (3 transits never visible) and 1 (3+ transits always visible) especially at periods 
+between 300-700 days. Since targets observed for the same quarters (see "sorted_quarter_strings" and stellar 
+catalog "st_quarters") have the same window function, it is efficient to summarize all target window functions 
+by giving each Kepler ID (in allsortedkepids) a window_function_id (listed in window_function_id_arr). That 
+is, the approximated window function for a specific duration (with duration_index from wf_durations_in_hrs) 
+and period (with period_index from wf_periods_in_days) is given by: 
+window_func_arr[window_function_id_arr[findfirst(kepid,win_func_data.allsortedkepids)],duration_index,period_index].
+This is further optimized by choosing representative window functions that cover most of the data and then 
+assigning all other stars to an averaged window function. For example, the top 100 window functions cover 
+99.6% of Kepler targets with at least 4 quarters of data (e.g., the top 100), so window_function_id=101 
+corresponds to the window function chosen by a weighted average over the remaining 0.4% of targets. Targets 
+with fewer than 4 quarters of data (with the EX Investigation ID) do not have a representative window function 
+and are indicated with a window_function_id of -1. Contact Darin Ragozzine for more information. 

--- a/examples/poisson_tests/abc_setup.jl
+++ b/examples/poisson_tests/abc_setup.jl
@@ -65,6 +65,11 @@ module EvalSysSimModel
     cat_obs = setup_actual_planet_candidate_catalog(df_star, df_koi, usable_koi, sim_param_closure)
     ###
 
+    win_func_data = setup_win_func_data()
+    println("# Finished reading in window function data")
+    add_param_fixed(sim_param_closure,"win_func_data",win_func_data)
+
+
     global summary_stat_ref_closure = calc_summary_stats_obs_binned_rates(cat_obs,sim_param_closure, trueobs_cat = true)
   end
 
@@ -117,7 +122,7 @@ module SysSimABC
     global abc_plan = ABC.abc_pmc_plan_type(EvalSysSimModel.gen_data,EvalSysSimModel.calc_summary_stats,calc_distance_ltd, param_prior, is_valid=EvalSysSimModel.is_valid,
                                      num_part=npart, num_max_attempt=50, num_max_times=1, epsilon_init=9.9e99, target_epsilon=1.0e-100, in_parallel=in_parallel);
 
-    println("# run_abc_largegen: ",EvalSysSimModel.sim_param_closure)
+    #println("# run_abc_largegen: ",EvalSysSimModel.sim_param_closure)
     sampler_largegen = abc_plan.make_proposal_dist(pop, abc_plan.tau_factor)
     theta_largegen = Array{Float64}(size(pop.theta, 1), npart)
     weight_largegen = Array{Float64}(npart)
@@ -133,7 +138,7 @@ module SysSimABC
 
   function run_abc(abc_plan::ABC.abc_pmc_plan_type)
     #global sim_param_closure
-    println("# run_abc: ",EvalSysSimModel.sim_param_closure)
+#    println("# run_abc: ",EvalSysSimModel.sim_param_closure)
     ss_true = EvalSysSimModel.get_ss_obs()
     #println("True catalog SS: ", ss_true)
     pop_out = ABC.run_abc(abc_plan,ss_true;verbose=true)
@@ -143,7 +148,7 @@ module SysSimABC
     #global sim_param_closure
     dist_threshold = maximum(pop.dist)
     EvalSysSimModel.add_param_fixed(EvalSysSimModel.sim_param_closure,"minimum ABC dist skip pass 2",dist_threshold)
-    println("# run_abc: ",EvalSysSimModel.sim_param_closure)
+    #println("# run_abc: ",EvalSysSimModel.sim_param_closure)
     ss_true = EvalSysSimModel.get_ss_obs()
     pop_out = ABC.run_abc(abc_plan,ss_true,pop;verbose=true)
   end

--- a/src/ExoplanetsSysSim.jl
+++ b/src/ExoplanetsSysSim.jl
@@ -38,6 +38,7 @@ export  StellarTable
 export setup_star_table, star_table, num_usable_in_star_table, set_star_table
 export KeplerTarget
 export num_planets, generate_kepler_target_from_table, generate_kepler_target_simple
+export setup_win_func_data
 include("target.jl")
 export KeplerTargetObs
 include("transit_observations.jl")

--- a/src/target.jl
+++ b/src/target.jl
@@ -37,8 +37,27 @@ function make_cdpp_array(star_id::Integer)
   cdpp_arr = (1.0e-6*sqrt(1./24.0/LC_duration)) .* Float64[star_table(star_id, :rrmscdpp01p5)*sqrt(1.5), star_table(star_id, :rrmscdpp02p0)*sqrt(2.), star_table(star_id,:rrmscdpp02p5)*sqrt(2.5), star_table(star_id,:rrmscdpp03p0)*sqrt(3.), star_table(star_id,:rrmscdpp03p5)*sqrt(3.5), star_table(star_id,:rrmscdpp04p5)*sqrt(4.5), star_table(star_id,:rrmscdpp05p0)*sqrt(5.), star_table(star_id,:rrmscdpp06p0)*sqrt(6.), star_table(star_id,:rrmscdpp07p5)*sqrt(7.5), star_table(star_id,:rrmscdpp09p0)*sqrt(9.), star_table(star_id,:rrmscdpp10p5)*sqrt(10.5), star_table(star_id,:rrmscdpp12p0)*sqrt(12.), star_table(star_id,:rrmscdpp12p5)*sqrt(12.5), star_table(star_id,:rrmscdpp15p0)*sqrt(15.)]
 end
  
-function set_window_function_id(star_id::Integer)
-  wf_id = 0 # TODO: DARIN Set to index containing window function information from stellar table
+function set_window_function_id(kepid::Int64)
+  # takes the quarter string from the stellar catalog and determines the window function id
+  # from DR25topwinfuncs.jld made by Darin Ragozzine's cleanDR25winfuncs.jl script. 
+
+  wf_id = win_func_data.window_function_id_arr[findfirst(win_func_data.allsortedkepids,kepid)] # all Kepler kepids are in allsortedkepids
+
+  no_win_func_available=-1
+#  default_window_function_id=maximum(win_func_data.window_function_id_arr)
+  default_window_function_id=101 # hardcoding this in
+
+  if wf_id == no_win_func_available
+    # if a target is observed for less than 4 quarters, then it won't have a corresponding
+    # window function in this list, so throw a warning and use the last window_function_id
+    # which corresponds to an "averaged" window function
+    warn("Window function data is not avaialble for kepid $kepid, using default.")
+    wf_id = default_window_function_id
+  end
+  # TODO SCI IMPORTANT? This does not include TPS timeouts or MESthresholds (see DR25 Completeness Products)
+
+  return(wf_id) 
+
 end
 
 
@@ -81,7 +100,7 @@ function generate_kepler_target_from_table(sim_param::SimParam)
   contam = 0.0 # rand(LogNormal(1.0e-3,1.0))      # TODO SCI: Come up with better description of Kepler targets, maybe draw from real contaminations
   data_span = star_table(star_id, :dataspan)
   duty_cycle = star_table(star_id, :dutycycle)
-  wf_id = set_window_function_id(star_id)
+  wf_id = set_window_function_id(star_table(star_id,:kepid))
   # ch = rand(DiscreteUniform(1,84))              # Removed channel in favor of window function id
   ps = generate_planetary_system(star, sim_param)  
   return KeplerTarget([ps],repeat(cdpp_arr, outer=[1,1]),contam,data_span,duty_cycle,wf_id)

--- a/src/transit_observations.jl
+++ b/src/transit_observations.jl
@@ -258,6 +258,11 @@ function calc_expected_num_transits(t::KeplerTarget, s::Integer, p::Integer, sim
  end
  # TODO SCI DETAIL: Calculate more accurat number of transits, perhaps using star and specific window function or perhaps specific times of data gaps more given module
   DARIN: Could your window function files help here?
+  REPLY: We decided in our discussion that this was not useful, mostly because
+  the window function only has information between 2 and 3 transits. Also, since
+  window functions average over phase and phase might be important for TTVs, 
+  we didn't want to include that here. Finally, the One Sigma Depth functions
+  are effectively going to replace this expected_num_transits calculation anyway.
  =#
  return exp_num_transits
 end


### PR DESCRIPTION
I have implemented in SysSim functions that read in the new window function data and assign a window_function_id to every kepid; these are working. Some of the machinery for calculating the window functions is there, but I didn't finish testing it, so I decided not to send it up. I'll try to work on that this weekend and get it to you by Monday. This will also give me a chance to update the window function data to be more useful (which takes a couple days).
 
Also, it looks like Danley has not yet included the cut of targets that were observed for less than 5 quarters (under the EX program, but that's not essential). This leads to ~few % of targets that use a default window function (which is actually a bad approximation for these poorly observed targets). This currently leads to several warnings. 